### PR TITLE
add Alpine Linux instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ brew tap cjbassi/ytop
 brew install ytop
 ```
 
+### Alpine Linux
+
+Available in the testing repository, so you need to be on Alpine Linux Edge.
+
+```bash
+apk add ytop
+```
+
 ### From source
 
 ```bash


### PR DESCRIPTION
Someone recently [contributed](https://gitlab.alpinelinux.org/alpine/aports/merge_requests/4714)  ytop and it has [made](https://git.alpinelinux.org/aports/commit/?id=fed1c36db56ef64f3b003d745cd65563fd5bd05e) into Alpine Linux's testing repository.

![image](https://user-images.githubusercontent.com/30738253/75501673-6b25a700-59af-11ea-844f-79376d2eefcb.png)
