### PR TITLE
Fix rendering of three digit temperatures

### DIFF
--- a/src/widgets/temp.rs
+++ b/src/widgets/temp.rs
@@ -88,9 +88,9 @@ impl Widget for TempWidget<'_> {
 			let y = inner.y + i as u16;
 			buf.set_string(inner.x, y, label, self.colorscheme.text);
 			buf.set_string(
-				inner.right() - 4,
+				inner.right() - 5,
 				y,
-				format!("{:2.0}°{}", data, if self.fahrenheit { "F" } else { "C" },),
+				format!("{:3.0}°{}", data, if self.fahrenheit { "F" } else { "C" },),
 				if data < &self.temp_threshold {
 					self.colorscheme.temp_low
 				} else {


### PR DESCRIPTION
When using the -f option to display temperatures in Fahrenheit,
I noticed the text escapes the box when rendering three digits:

```
┌ Temperatures ────────────────────────────────────────────┐
│coretemp-Core 10                                      106°F
│coretemp-Core 0                                       97°F│
```

With this fix, they are properly contained:

```
┌ Temperatures ─────────────────────────────────────────┐
│coretemp-Core 8                                   102°F│
│coretemp-Core 9                                   104°F│
```

I also verified that Celsius still renders correctly:

```
┌ Temperatures ────────────────────────────────────────────┐
│coretemp-Core 8                                       43°C│
```