### PR TITLE
[WIP] Ability to not follow a process

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -244,6 +244,8 @@ fn main() {
 									if show_help_menu {
 										show_help_menu = false;
 										draw(&mut terminal, &mut app);
+									} else {
+										app.widgets.proc.no_follow_proc();
 									}
 								}
 								KeyCode::Tab => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -244,8 +244,6 @@ fn main() {
 									if show_help_menu {
 										show_help_menu = false;
 										draw(&mut terminal, &mut app);
-									} else {
-										app.widgets.proc.no_follow_proc();
 									}
 								}
 								KeyCode::Tab => {
@@ -266,6 +264,10 @@ fn main() {
 								},
 								KeyCode::Char('m') => {
 									app.widgets.proc.sort_by_mem();
+									proc_modified = true;
+								},
+								KeyCode::Char('f') => {
+									app.widgets.proc.toggle_follow_proc();
 									proc_modified = true;
 								},
 								_ => {}

--- a/src/widgets/help_menu.rs
+++ b/src/widgets/help_menu.rs
@@ -22,6 +22,7 @@ Process navigation:
 Process actions:
   - <Tab>: toggle process grouping
   - dd: kill selected process or process group
+  - f: toggle process following
 Process sorting:
   - p: PID/Count
   - n: Command

--- a/src/widgets/proc.rs
+++ b/src/widgets/proc.rs
@@ -151,7 +151,6 @@ impl ProcWidget<'_> {
 
 	pub fn scroll_top(&mut self) {
 		self.scroll_to(0);
-		self.follow_proc = false;
 	}
 
 	pub fn scroll_bottom(&mut self) {
@@ -216,8 +215,8 @@ impl ProcWidget<'_> {
 		self.sort(SortMethod::Mem);
 	}
 
-	pub fn no_follow_proc(&mut self) {
-		self.follow_proc = false;
+	pub fn toggle_follow_proc(&mut self) {
+		self.follow_proc = !self.follow_proc;
 	}
 }
 
@@ -395,11 +394,12 @@ impl Widget for &mut ProcWidget<'_> {
 		.block(block::new(
 			self.colorscheme,
 			&format!(
-				" {} ({}-{} of {}) ",
+				" {} ({}-{} of {}) {}",
 				self.title,
 				self.view_offset + 1,
 				self.view_offset + self.view_height,
-				procs_count
+				procs_count,
+				if self.follow_proc { "F " } else { "" }
 			),
 		))
 		.header_style(self.colorscheme.text.modifier(Modifier::BOLD))


### PR DESCRIPTION
This introduces an ability to not-follow a process in the `proc` widget.
I  having to do `gg` whenever I visit `ytop` to find out the process
which is currently using high mem/CPU. It'd be great to have the ability
to not always track the currently highlighted process.

This patch is a POC for that. What it does is:

 - Introduce a new flag on the widget: `follow_proc`, which is false by
   default. If it is set to `true`, the `render` will always jump to the
   position for the highlighted position. If it is `false`, it'll keep
   the selected position the same, no matter which process lands on it.
 - When ever the user does a scroll action (except `gg`), `ytop` will
   keep track of the process. `gg` or scroll to top on the other hand,
   stops the process tracking facilitating a view such as: the current
   process taking the most resources.
 - Also, bind `Esc` to set `follow_proc` as false and disable following
   of a process.

I understand this cannot be merged as is, but I'd like to start a
discussion. If this makes sense, I'd like suggestions on what can be
changed in the patch to merge it in.