### PR TITLE
Only scale by visible network values

### DIFF
--- a/src/sparkline.rs
+++ b/src/sparkline.rs
@@ -64,6 +64,7 @@ impl<'a> Sparkline<'a> {
 		self
 	}
 
+	#[allow(dead_code)]
 	pub fn max(mut self, max: u64) -> Sparkline<'a> {
 		self.max = Some(max);
 		self

--- a/src/widgets/net.rs
+++ b/src/widgets/net.rs
@@ -155,12 +155,11 @@ impl Widget for &NetWidget<'_, '_> {
 					.iter()
 					.cloned()
 					.rev()
-					.collect::<Vec<u64>>()
-					.as_slice(),
+					.take(top_sparkline.width as usize)
+					.collect::<Vec<_>>(),
 			)
 			.direction(RenderDirection::RTL)
 			.show_baseline(true)
-			.max(*self.bytes_recv.iter().max().unwrap())
 			.style(self.colorscheme.net_bars)
 			.render(top_sparkline, buf);
 
@@ -192,12 +191,11 @@ impl Widget for &NetWidget<'_, '_> {
 					.iter()
 					.cloned()
 					.rev()
-					.collect::<Vec<u64>>()
-					.as_slice(),
+					.take(bottom_sparkline.width as usize)
+					.collect::<Vec<_>>(),
 			)
 			.direction(RenderDirection::RTL)
 			.show_baseline(true)
-			.max(*self.bytes_sent.iter().max().unwrap())
 			.style(self.colorscheme.net_bars)
 			.render(bottom_sparkline, buf);
 	}


### PR DESCRIPTION
Previously the scaling would be based on all network entries recorded instead of just the network entries displayed. This meant that high transmission or reception rates would cause the scaling to drown out any small entries even if the high rates were not being displayed. This change passes in just the amount of samples needed to fill the block and let's the `Sparkline` calculate the `max` internally.

Luckily all the hard work seemed to be done already so this change was a joy to make.

Possibly related (#90)