### PR TITLE
Ignore `bond` as well as `tun` for network activity

### DIFF
--- a/src/widgets/net.rs
+++ b/src/widgets/net.rs
@@ -12,7 +12,8 @@ use crate::colorscheme::Colorscheme;
 use crate::update::UpdatableWidget;
 use crate::widgets::block;
 
-const VPN_INTERFACE: &str = "tun0";
+const BOND_INTERFACE_PRFIX: &str = "bond";
+const TUN_INTERFACE_PREFIX: &str = "tun";
 
 pub struct NetWidget<'a, 'b> {
 	title: String,
@@ -62,9 +63,14 @@ impl UpdatableWidget for NetWidget<'_, '_> {
 			.unwrap()
 			.into_iter()
 			.filter(|(name, _counters)| {
-				// Filter out the VPN interface unless specified directly since it gets double
+				// Filter out tunnels and bonds unless specified directly since it gets double
 				// counted along with the hardware interfaces it is operating on.
-				(self.interface == "all" && name != VPN_INTERFACE) || name == self.interface
+				// TODO: Ideally it would be good to detect if the interface is virtual instead of
+				//       hardcoding these cases
+				(self.interface == "all"
+					&& !name.starts_with(TUN_INTERFACE_PREFIX)
+					&& !name.starts_with(BOND_INTERFACE_PRFIX))
+					|| name == self.interface
 			})
 			.map(|(_name, counters)| counters)
 			.sum();

--- a/src/widgets/net.rs
+++ b/src/widgets/net.rs
@@ -12,7 +12,7 @@ use crate::colorscheme::Colorscheme;
 use crate::update::UpdatableWidget;
 use crate::widgets::block;
 
-const BOND_INTERFACE_PRFIX: &str = "bond";
+const BOND_INTERFACE_PREFIX: &str = "bond";
 const TUN_INTERFACE_PREFIX: &str = "tun";
 
 pub struct NetWidget<'a, 'b> {
@@ -69,7 +69,7 @@ impl UpdatableWidget for NetWidget<'_, '_> {
 				//       hardcoding these cases
 				(self.interface == "all"
 					&& !name.starts_with(TUN_INTERFACE_PREFIX)
-					&& !name.starts_with(BOND_INTERFACE_PRFIX))
+					&& !name.starts_with(BOND_INTERFACE_PREFIX))
 					|| name == self.interface
 			})
 			.map(|(_name, counters)| counters)


### PR DESCRIPTION
**Addresses: #92**

The network graph already had logic to ignore just `tun0`. However, having multiple `tun`s or in the case of #92 having a `bond` will still cause the problem of counting for the virtual and physical network device. This change just changes the logic to ignore all tunnels and bonds.

Just as a note for future work it would be nice to have a way of detecting and filtering out virtual devices instead of dealing with all of these cases separately, but it looks like `rust-psutil` doesn't have that functionality yet.