### PR TITLE
Fix disk I/O usage metrics

### DIFF
--- a/src/widgets/disk.rs
+++ b/src/widgets/disk.rs
@@ -82,8 +82,8 @@ impl UpdatableWidget for DiskWidget<'_> {
 					.remove(&partition.device().replace("/dev/", ""))
 					.unwrap_or_default();
 
-				let bytes_read = io_counters.read_count();
-				let bytes_written = io_counters.read_count();
+				let bytes_read = io_counters.read_bytes();
+				let bytes_written = io_counters.write_bytes();
 				// Here we use an `unwrap_or_default` for when we are adding a new disk partition
 				// that is loaded when on ytop is already running.
 				let (bytes_read_recently, bytes_written_recently) = self


### PR DESCRIPTION
Previously, disk I/O usage counters displayed invalid values.
Idk how this was missed, I assume this was tested only on OS X.
Regardless, thanks for the tool!