### PR TITLE
Provide fallback value for unwrap where appropriate

### DIFF
--- a/src/widgets/battery.rs
+++ b/src/widgets/battery.rs
@@ -99,7 +99,7 @@ impl Widget for &BatteryWidget<'_> {
 			buf.set_string(
 				area.x + 3,
 				area.y + 2 + i as u16,
-				format!("{} {:3.0}%", data.0, data.1.last().unwrap().1),
+				format!("{} {:3.0}%", data.0, data.1.last().unwrap_or(&(0.0, 0.0)).1),
 				self.colorscheme.battery_lines[i % self.colorscheme.battery_lines.len()],
 			);
 		}

--- a/src/widgets/cpu.rs
+++ b/src/widgets/cpu.rs
@@ -158,7 +158,10 @@ impl Widget for &CpuWidget<'_> {
 			buf.set_string(
 				area.x + 3,
 				area.y + 2,
-				format!("AVRG {:3.0}%", self.average_data.last().unwrap().1),
+				format!(
+					"AVRG {:3.0}%",
+					self.average_data.last().unwrap_or(&(0.0, 0.0)).1
+				),
 				self.colorscheme.cpu_lines[0],
 			);
 		}
@@ -173,7 +176,11 @@ impl Widget for &CpuWidget<'_> {
 				buf.set_string(
 					area.x + 3,
 					y,
-					format!("CPU{} {:3.0}%", i, self.percpu_data[i].last().unwrap().1),
+					format!(
+						"CPU{} {:3.0}%",
+						i,
+						self.percpu_data[i].last().unwrap_or(&(0.0, 0.0)).1
+					),
 					self.colorscheme.cpu_lines
 						[(i + offset as usize) % self.colorscheme.cpu_lines.len()],
 				);

--- a/src/widgets/disk.rs
+++ b/src/widgets/disk.rs
@@ -67,7 +67,7 @@ impl UpdatableWidget for DiskWidget<'_> {
 					.file_name()
 					.unwrap()
 					.to_string_lossy()
-					.to_string();
+					.into_owned();
 				let mountpoint = partition.mountpoint().to_path_buf();
 
 				// We use `unwrap_or_default` since the function may return an error if there is

--- a/src/widgets/mem.rs
+++ b/src/widgets/mem.rs
@@ -135,7 +135,7 @@ impl Widget for &MemWidget<'_> {
 			area.y + 2,
 			format!(
 				"Main {:3.0}% {}/{}",
-				self.main.percents.last().unwrap().1,
+				self.main.percents.last().unwrap_or(&(0.0, 0.0)).1,
 				Size::Bytes(self.main.used),
 				Size::Bytes(self.main.total),
 			),
@@ -148,7 +148,7 @@ impl Widget for &MemWidget<'_> {
 				area.y + 3,
 				format!(
 					"Swap {:3.0}% {}/{}",
-					swap.percents.last().unwrap().1,
+					swap.percents.last().unwrap_or(&(0.0, 0.0)).1,
 					Size::Bytes(swap.used),
 					Size::Bytes(swap.total),
 				),

--- a/src/widgets/net.rs
+++ b/src/widgets/net.rs
@@ -143,7 +143,7 @@ impl Widget for &NetWidget<'_, '_> {
 			top_half.y + 2,
 			format!(
 				"Rx/s:     {}/s",
-				Size::Bytes(self.bytes_recv.last().unwrap().to_owned())
+				Size::Bytes(self.bytes_recv.last().unwrap_or(&0).to_owned())
 			),
 			self.colorscheme.text.modifier(Modifier::BOLD),
 		);
@@ -160,7 +160,7 @@ impl Widget for &NetWidget<'_, '_> {
 			)
 			.direction(RenderDirection::RTL)
 			.show_baseline(true)
-			.max(*self.bytes_recv.iter().max().unwrap())
+			.max(*self.bytes_recv.iter().max().unwrap_or(&0))
 			.style(self.colorscheme.net_bars)
 			.render(top_sparkline, buf);
 
@@ -180,7 +180,7 @@ impl Widget for &NetWidget<'_, '_> {
 			bottom_half.y + 2,
 			format!(
 				"Tx/s:     {}/s",
-				Size::Bytes(self.bytes_sent.last().unwrap().to_owned())
+				Size::Bytes(self.bytes_sent.last().unwrap_or(&0).to_owned())
 			),
 			self.colorscheme.text.modifier(Modifier::BOLD),
 		);
@@ -197,7 +197,7 @@ impl Widget for &NetWidget<'_, '_> {
 			)
 			.direction(RenderDirection::RTL)
 			.show_baseline(true)
-			.max(*self.bytes_sent.iter().max().unwrap())
+			.max(*self.bytes_sent.iter().max().unwrap_or(&0))
 			.style(self.colorscheme.net_bars)
 			.render(bottom_sparkline, buf);
 	}


### PR DESCRIPTION
*Addresses: #80*

This PR just tries to reduce down the number of `unwrap`s used. In general, `unwrap` should be avoided over traditional error handling and mitigating with `unwrap_or`, `unwrap_or_default`, `expect`, etc. since it introduces possible ways to crash the program.